### PR TITLE
Fix style directives

### DIFF
--- a/src/lib/components/Image/Image.svelte
+++ b/src/lib/components/Image/Image.svelte
@@ -240,8 +240,8 @@
 		class={klass}
 		style:overflow="hidden"
 		style:position={style.position ?? layout === 'fill' ? 'absolute' : 'relative'}
-		style:width={style.width ?? layout === 'fixed' ? data.width : '100%'}
-		style:maxWidth={style.maxWidth ?? layout === 'intrinsic' ? data.width : null}
+		style:width={style.width ?? layout === 'fixed' ? `${data.width}px` : '100%'}
+		style:max-width={style.maxWidth ?? layout === 'intrinsic' ? `${data.width}px` : null}
 		style:height={style.height ?? layout === 'fill' ? '100%' : null}
 		data-testid="image"
 	>
@@ -290,8 +290,8 @@
 						style:top="0"
 						style:width="100%"
 						style:height="100%"
-						style:objectFit
-						style:objectPosition
+						style:object-fit={objectFit}
+						style:object-position={objectPosition}
 						data-testid="img"
 					/>
 				{/if}

--- a/src/lib/components/Image/Placeholder.svelte
+++ b/src/lib/components/Image/Placeholder.svelte
@@ -17,9 +17,9 @@
 	aria-hidden="true"
 	alt=""
 	src={base64}
-	style:backgroundColor
-	style:objectFit
-	style:objectPosition
+	style:background-color={backgroundColor}
+	style:object-fit={objectFit}
+	style:object-position={objectPosition}
 	style:transition
 	style:opacity
 />

--- a/src/lib/components/Image/__tests__/__snapshots__/Image.svelte.test.ts.snap
+++ b/src/lib/components/Image/__tests__/__snapshots__/Image.svelte.test.ts.snap
@@ -199,7 +199,7 @@ exports[`Image > layout=fixed > data=completeData > when the component doesn't i
   <div>
     <div
       data-testid="image"
-      style="overflow: hidden; position: relative;"
+      style="overflow: hidden; position: relative; width: 750px;"
     >
       <img
         alt=""
@@ -230,7 +230,7 @@ exports[`Image > layout=fixed > data=completeData > when the component intersect
   <div>
     <div
       data-testid="image"
-      style="overflow: hidden; position: relative;"
+      style="overflow: hidden; position: relative; width: 750px;"
     >
       <img
         alt=""
@@ -279,7 +279,7 @@ exports[`Image > layout=fixed > data=minimalData > when the component doesn't in
   <div>
     <div
       data-testid="image"
-      style="overflow: hidden; position: relative;"
+      style="overflow: hidden; position: relative; width: 750px;"
     >
       <img
         alt=""
@@ -310,7 +310,7 @@ exports[`Image > layout=fixed > data=minimalData > when the component intersects
   <div>
     <div
       data-testid="image"
-      style="overflow: hidden; position: relative;"
+      style="overflow: hidden; position: relative; width: 750px;"
     >
       <img
         alt=""
@@ -357,7 +357,7 @@ exports[`Image > layout=fixed > data=minimalDataWithRelativeUrl > when the compo
   <div>
     <div
       data-testid="image"
-      style="overflow: hidden; position: relative;"
+      style="overflow: hidden; position: relative; width: 750px;"
     >
       <img
         alt=""
@@ -388,7 +388,7 @@ exports[`Image > layout=fixed > data=minimalDataWithRelativeUrl > when the compo
   <div>
     <div
       data-testid="image"
-      style="overflow: hidden; position: relative;"
+      style="overflow: hidden; position: relative; width: 750px;"
     >
       <img
         alt=""
@@ -435,7 +435,7 @@ exports[`Image > layout=intrinsic > data=completeData > when the component doesn
   <div>
     <div
       data-testid="image"
-      style="overflow: hidden; position: relative; width: 100%;"
+      style="overflow: hidden; position: relative; width: 100%; max-width: 750px;"
     >
       <img
         alt=""
@@ -466,7 +466,7 @@ exports[`Image > layout=intrinsic > data=completeData > when the component inter
   <div>
     <div
       data-testid="image"
-      style="overflow: hidden; position: relative; width: 100%;"
+      style="overflow: hidden; position: relative; width: 100%; max-width: 750px;"
     >
       <img
         alt=""
@@ -515,7 +515,7 @@ exports[`Image > layout=intrinsic > data=minimalData > when the component doesn'
   <div>
     <div
       data-testid="image"
-      style="overflow: hidden; position: relative; width: 100%;"
+      style="overflow: hidden; position: relative; width: 100%; max-width: 750px;"
     >
       <img
         alt=""
@@ -546,7 +546,7 @@ exports[`Image > layout=intrinsic > data=minimalData > when the component inters
   <div>
     <div
       data-testid="image"
-      style="overflow: hidden; position: relative; width: 100%;"
+      style="overflow: hidden; position: relative; width: 100%; max-width: 750px;"
     >
       <img
         alt=""
@@ -593,7 +593,7 @@ exports[`Image > layout=intrinsic > data=minimalDataWithRelativeUrl > when the c
   <div>
     <div
       data-testid="image"
-      style="overflow: hidden; position: relative; width: 100%;"
+      style="overflow: hidden; position: relative; width: 100%; max-width: 750px;"
     >
       <img
         alt=""
@@ -624,7 +624,7 @@ exports[`Image > layout=intrinsic > data=minimalDataWithRelativeUrl > when the c
   <div>
     <div
       data-testid="image"
-      style="overflow: hidden; position: relative; width: 100%;"
+      style="overflow: hidden; position: relative; width: 100%; max-width: 750px;"
     >
       <img
         alt=""


### PR DESCRIPTION
In Svelte, a style directive is an attribute applied to an element in the format style:property={value}, where property is a CSS property name and value is the value of that property.