### PR TITLE
VideoPlayer: use data.thumbnailUrl as poster unless overridden

### DIFF
--- a/src/lib/components/VideoPlayer/VideoPlayer.svelte
+++ b/src/lib/components/VideoPlayer/VideoPlayer.svelte
@@ -102,6 +102,8 @@
 		playbackId?: Maybe<string>;
 		/** A data: URI containing a blurhash for the video  */
 		blurUpThumb?: Maybe<string>;
+		/** A URL for the video thumbnail, used as the poster image */
+		thumbnailUrl?: Maybe<string>;
 	};
 
 	type VideoPlayerProps = Partial<MuxPlayerProps> & {
@@ -138,6 +140,10 @@
 
 	const computedPlaceholder = (blurUpThumb: Possibly<string>) => {
 		return blurUpThumb ? { placeholder: blurUpThumb } : undefined;
+	};
+
+	const computedPoster = (thumbnailUrl: Possibly<string>) => {
+		return thumbnailUrl ? { poster: thumbnailUrl } : undefined;
 	};
 
 	type KeyTypes = string | number | symbol;
@@ -233,6 +239,7 @@
 			width,
 			height,
 			blurUpThumb,
+			thumbnailUrl,
 			alt: dataAlt
 		} = data || {};
 
@@ -246,6 +253,7 @@
 			...(computedPlaybackId(muxPlaybackId, playbackId) || {}),
 			...(computedStyle(style, width, height) || {}),
 			...(computedPlaceholder(blurUpThumb) || {}),
+			...(computedPoster(thumbnailUrl) || {}),
 			disableCookies,
 			disableTracking,
 			preload

--- a/src/lib/components/VideoPlayer/__tests__/VideoPlayer.svelte.test.ts
+++ b/src/lib/components/VideoPlayer/__tests__/VideoPlayer.svelte.test.ts
@@ -166,6 +166,31 @@ describe('VideoPlayer', () => {
 			});
 		});
 
+		describe('contains `thumbnailUrl`', () => {
+			const data = {
+				muxPlaybackId: 'ip028MAXF026dU900bKiyNDttjonw7A1dFY',
+				thumbnailUrl: 'https://example.com/thumb.jpg'
+			};
+
+			it('uses it for the `poster` of the <mux-player /> element', () => {
+				const props = { data };
+
+				const { container } = render(VideoPlayer, { props });
+
+				expect(container).toMatchSnapshot();
+			});
+
+			describe('and a `poster` is also passed', () => {
+				it('uses the passed `poster` value instead', () => {
+					const props = { data, poster: 'https://example.com/custom-poster.jpg' };
+
+					const { container } = render(VideoPlayer, { props });
+
+					expect(container).toMatchSnapshot();
+				});
+			});
+		});
+
 		describe('lacks of `width` and `height` values', () => {
 			const data = {
 				muxPlaybackId: 'ip028MAXF026dU900bKiyNDttjonw7A1dFY',

--- a/src/lib/components/VideoPlayer/__tests__/__snapshots__/VideoPlayer.svelte.test.ts.snap
+++ b/src/lib/components/VideoPlayer/__tests__/__snapshots__/VideoPlayer.svelte.test.ts.snap
@@ -30,6 +30,38 @@ exports[`VideoPlayer > when data object > contains \`playbackId\` > uses it for 
 </body>
 `;
 
+exports[`VideoPlayer > when data object > contains \`thumbnailUrl\` > and a \`poster\` is also passed > uses the passed \`poster\` value instead 1`] = `
+<body>
+  <div>
+    <mux-player
+      disable-cookies="true"
+      disable-tracking="true"
+      playback-id="ip028MAXF026dU900bKiyNDttjonw7A1dFY"
+      poster="https://example.com/custom-poster.jpg"
+      preload="metadata"
+      stream-type="on-demand"
+    />
+    <!--&lt;VideoPlayer&gt;-->
+  </div>
+</body>
+`;
+
+exports[`VideoPlayer > when data object > contains \`thumbnailUrl\` > uses it for the \`poster\` of the <mux-player /> element 1`] = `
+<body>
+  <div>
+    <mux-player
+      disable-cookies="true"
+      disable-tracking="true"
+      playback-id="ip028MAXF026dU900bKiyNDttjonw7A1dFY"
+      poster="https://example.com/thumb.jpg"
+      preload="metadata"
+      stream-type="on-demand"
+    />
+    <!--&lt;VideoPlayer&gt;-->
+  </div>
+</body>
+`;
+
 exports[`VideoPlayer > when data object > is complete > and \`autoplay\` is passed > uses it for the <mux-player /> element 1`] = `
 <body>
   <div>


### PR DESCRIPTION
Default the Mux player's poster to the video's `thumbnailUrl` when present. An explicitly passed poster prop still takes precedence, since `restProps` are spread after the computed props on `<mux-player />`.